### PR TITLE
Wire custom prompts through tailor flow

### DIFF
--- a/api/core/prompting.py
+++ b/api/core/prompting.py
@@ -71,11 +71,25 @@ TASK:
 Rewrite the resume to match the JD. Preserve employers/titles/dates/education. No metrics. No JD copy-paste.
 Output ONLY the resume text."""
 
-def render_custom_prompt(vars: Dict[str, str]) -> str:
+def render_custom_prompt(template: str | None, vars: Dict[str, str]) -> str:
     # Only allow a fixed set of keys
     safe_vars = {k: v for k, v in vars.items() if k in ALLOWED_KEYS}
+    base_template = template or DEFAULT_CUSTOM_TEMPLATE
 
-    return DEFAULT_CUSTOM_TEMPLATE.format(**safe_vars)
+    if "{RESUME}" in base_template or "{JD}" in base_template or "{MODE}" in base_template:
+        try:
+            return base_template.format(**safe_vars)
+        except Exception:
+            return base_template
+
+    return f"""{base_template}
+
+BASE RESUME:
+{safe_vars.get("RESUME", "")}
+
+JOB DESCRIPTION:
+{safe_vars.get("JD", "")}
+"""
 
 def build_default_user_prompt(
         mode: str,

--- a/api/core/tailor.py
+++ b/api/core/tailor.py
@@ -20,11 +20,13 @@ def tailor_text(
         "MODE": mode,
         "RESUME": resume_text,
         "JD": jd_text,
+        "ALLOWED": "\n".join(allowed),
+        "DISALLOWED": "\n".join(disallowed),
     }
     
     system = DEFAULT_SYSTEM_PROMPT
-    if prompt_mode == "custom" and custom_prompt:
-        user = render_custom_prompt(vars)
+    if prompt_mode == "custom":
+        user = render_custom_prompt(custom_prompt, vars)
     else:
         user = build_default_user_prompt(mode, resume_text, jd_text)
     if mode == "evil":
@@ -42,4 +44,3 @@ def tailor_text(
         raise HTTPException(status_code=400, detail="Tailored output removed EDUCATION section. Regenerate.")
 
     return content
-

--- a/api/routes.py
+++ b/api/routes.py
@@ -24,7 +24,15 @@ def health():
 @router.post("/tailor", response_model=TailorResponse)
 def tailor(req: TailorRequest):
     try:
-        out = tailor_text(req.resume_text, req.jd_text, req.tolerance, req.provider)
+        out = tailor_text(
+            req.resume_text,
+            req.jd_text,
+            req.tolerance,
+            req.provider,
+            model=req.model,
+            prompt_mode=req.prompt_mode,
+            custom_prompt=req.custom_prompt,
+        )
         return TailorResponse(tailored_resume=out)
     except HTTPException:
         raise
@@ -56,7 +64,10 @@ def batch_zip(req: BatchZipRequest):
             job_urls=req.job_urls,
             tolerance=req.tolerance,
             fmt=req.format,
-            provider=req.provider
+            provider=req.provider,
+            model=req.model,
+            prompt_mode=req.prompt_mode,
+            custom_prompt=req.custom_prompt,
         )
         headers = {"Content-Disposition": 'attachment; filename="tailored_resumes.zip"'}
         return StreamingResponse(zip_buf, media_type="application/zip", headers=headers)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -57,7 +57,7 @@ class TailorRequest(BaseModel):
     provider: Literal["ollama", "deepseek"] = "ollama"
     model: Optional[str] = None
 
-    prompt_mode: Literal["detailed", "custom"] = "default"
+    prompt_mode: Literal["default", "custom"] = "default"
     custom_prompt: Optional[str] = None
 
 class TailorResponse(BaseModel):
@@ -81,5 +81,5 @@ class BatchZipRequest(BaseModel):
     provider: Literal["ollama", "deepseek"] = "ollama"
     model: Optional[str] = None
 
-    prompt_mode: Literal["detailed", "custom"] = "default"
+    prompt_mode: Literal["default", "custom"] = "default"
     custom_prompt: Optional[str] = None

--- a/api/services/batch.py
+++ b/api/services/batch.py
@@ -20,6 +20,9 @@ def build_zip(
     tolerance: int,
     fmt: Literal["pdf", "pdf+txt"],
     provider: Literal["ollama", "deepseek"],
+    model: str | None = None,
+    prompt_mode: Literal["default", "custom"] = "default",
+    custom_prompt: str | None = None,
 ) -> BytesIO:
     zip_buf = BytesIO()
     errors = []
@@ -28,7 +31,15 @@ def build_zip(
         for idx, url in enumerate(job_urls[:10], start=1):
             try:
                 jd_text = fetch_jd_text(url)
-                resume_txt = tailor_text(base_resume_text, jd_text, tolerance, provider).strip()
+                resume_txt = tailor_text(
+                    base_resume_text,
+                    jd_text,
+                    tolerance,
+                    provider,
+                    model=model,
+                    prompt_mode=prompt_mode,
+                    custom_prompt=custom_prompt,
+                ).strip()
 
                 base_name = f"{idx:02d}_{slugify(url)}"
                 pdf = render_resume_pdf(resume_txt).getvalue()

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -79,6 +79,8 @@ export default function Home() {
           jd_text: jdText,
           tolerance,
           provider,
+          prompt_mode: promptMode,
+          custom_prompt: promptMode === "custom" ? customPrompt : null,
           plan: null,
         }),
       });
@@ -183,6 +185,8 @@ export default function Home() {
           tolerance,
           provider,
           format: "pdf+txt",
+          prompt_mode: promptMode,
+          custom_prompt: promptMode === "custom" ? customPrompt : null,
         }),
       });
 


### PR DESCRIPTION
### Motivation
- Allow the frontend custom prompt UI to actually control backend behavior by propagating `prompt_mode` and `custom_prompt` through the tailoring and batch flows. 
- Let custom prompt templates include policy context (e.g., `ALLOWED` / `DISALLOWED`) and base resume/JD content so users can fully customize output. 
- Fix schema mismatch for `prompt_mode` and ensure batch generation honors the same prompt settings as single tailoring. 

### Description
- Changed `render_custom_prompt` signature to `render_custom_prompt(template: str | None, vars: Dict[str,str])` and updated logic to accept an explicit template or append `BASE RESUME` / `JOB DESCRIPTION` when template lacks placeholders. 
- Include `ALLOWED` and `DISALLOWED` in the `vars` passed to prompt rendering and updated `DEFAULT_CUSTOM_TEMPLATE` formatting in `api/core/prompting.py`. 
- Updated `tailor_text` to accept `model`, `prompt_mode`, and `custom_prompt` and to call `render_custom_prompt(custom_prompt, vars)` when `prompt_mode == "custom"`. 
- Propagated `model`, `prompt_mode`, and `custom_prompt` through HTTP handlers in `api/routes.py`, the batch builder in `api/services/batch.py`, and updated the frontend `web/app/page.tsx` to send `prompt_mode` and `custom_prompt` for both tailor and batch requests. 
- Fixed `prompt_mode` schema literals in `api/schemas.py` to `Literal["default", "custom"]`. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6217a008832d829b6ac33fab18d4)